### PR TITLE
Feature/instance dependent ldap model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 1.0.0
+
+* Feature: Add support for WebSEAL/IBM ISAM.
+* Breaking change: Connections to the LDAP server are no longer established
+  automatically (see README).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,33 @@
 PATH
   remote: .
   specs:
-    ldap_model (0.1.0)
-      activemodel (~> 3.2)
+    ldap_model (0.3.0)
+      activemodel (>= 3.2)
       net-ldap
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (3.2.17)
-      activesupport (= 3.2.17)
-      builder (~> 3.0.0)
-    activesupport (3.2.17)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
-    builder (3.0.4)
-    i18n (0.6.9)
-    multi_json (1.8.4)
-    net-ldap (0.3.1)
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.0.2)
+    i18n (0.7.0)
+    minitest (5.9.1)
+    net-ldap (0.15.0)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   ldap_model!
+
+BUNDLED WITH
+   1.13.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ldap_model (0.3.0)
+    ldap_model (0.4.0)
       activemodel (>= 3.2)
       net-ldap
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2016 IFAD
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-ldap-model
-==========
+# ldap-model
 
 This is a work in progress. It's an ActiveModel-compliant class that
 interfaces with LDAP servers.
@@ -11,3 +10,26 @@ You can use this to provide a deep integration with Active Directory from your
 application. Changing and resetting passwords included.
 
 No tests for now, please have a look at the code.
+
+## Usage
+
+```ruby
+LDAP_SERVER = {
+  "hostname"   => "mydomain.com",
+  "encryption" => :start_tls,
+  "username"   => "my_ldap_user",
+  "password"   => "my_ldap_password",
+  "base"       => "DC=mydomain"
+}
+
+class Person < Model::AD::Person
+  establish_connection LDAP_SERVER
+end
+
+Person.find('CN=John Smith,DC=mydomain')
+=> #<Person dn: CN=John Smith,DC=mydomain>
+```
+
+## License
+
+[MIT license](LICENSE)

--- a/lib/ldap/model.rb
+++ b/lib/ldap/model.rb
@@ -1,6 +1,7 @@
 module LDAP
   module Model
     autoload :AD,              'ldap/model/ad'
+    autoload :ISDS,            'ldap/model/isds'
     autoload :Base,            'ldap/model/base'
     autoload :ActiveRecord,    'ldap/model/active_record'
     autoload :Instrumentation, 'ldap/model/instrumentation'

--- a/lib/ldap/model/ad/person.rb
+++ b/lib/ldap/model/ad/person.rb
@@ -3,14 +3,14 @@ module LDAP::Model
     include AD::Timestamps
 
     autoload :Avatar, 'ldap/model/ad/person/avatar'
-
-    validates :sAMAccountName, :givenName, presence: true
+    validates :givenName, presence: true
 
     binary_attributes %w[
       thumbnailPhoto
     ]
 
     string_attributes %w[
+      uid
       givenName
       sn
       name
@@ -117,6 +117,7 @@ module LDAP::Model
 
     define_attribute_methods(
       # User attributes
+      :uid              => 'uid',
       :account_name     => 'sAMAccountName',
       :email            => 'mail',
       :first_name       => 'givenName',

--- a/lib/ldap/model/ad/person.rb
+++ b/lib/ldap/model/ad/person.rb
@@ -3,14 +3,14 @@ module LDAP::Model
     include AD::Timestamps
 
     autoload :Avatar, 'ldap/model/ad/person/avatar'
-    validates :givenName, presence: true
+
+    validates :sAMAccountName, :givenName, presence: true
 
     binary_attributes %w[
       thumbnailPhoto
     ]
 
     string_attributes %w[
-      uid
       givenName
       sn
       name
@@ -117,7 +117,6 @@ module LDAP::Model
 
     define_attribute_methods(
       # User attributes
-      :uid              => 'uid',
       :account_name     => 'sAMAccountName',
       :email            => 'mail',
       :first_name       => 'givenName',

--- a/lib/ldap/model/ad/root.rb
+++ b/lib/ldap/model/ad/root.rb
@@ -1,7 +1,5 @@
 module LDAP::Model
   class AD::Root < Base
-    base connection.base
-
     string_attributes [
       'name',
 

--- a/lib/ldap/model/base.rb
+++ b/lib/ldap/model/base.rb
@@ -83,6 +83,7 @@ module LDAP::Model
 
       options[:scope]      ||= scope
       options[:attributes] ||= attributes
+      options[:connection] ||= connection
 
       if options[:filter].present?
         options[:filter] &= default_filter
@@ -91,7 +92,7 @@ module LDAP::Model
       end
 
       instrument(:search, options) do |event|
-        (connection.search(options) || []).tap do |result|
+        (options[:connection].search(options) || []).tap do |result|
           unless raw_entry
             result.map! {|entry| new(entry, :persisted => true)}
           end

--- a/lib/ldap/model/isds.rb
+++ b/lib/ldap/model/isds.rb
@@ -1,0 +1,5 @@
+module LDAP::Model
+  module ISDS
+    autoload :Person,     'ldap/model/isds/person'
+  end
+end

--- a/lib/ldap/model/isds/person.rb
+++ b/lib/ldap/model/isds/person.rb
@@ -1,0 +1,62 @@
+module LDAP::Model
+  class ISDS::Person < Base
+    validates :givenName, presence: true
+    validates :uid, presence: true
+
+    string_attributes %w[
+      uid
+      givenName
+      sn
+      displayName
+      mail
+    ]
+
+    class << self
+      def filter_only_person
+        Net::LDAP::Filter.eq('objectClass', 'person')
+      end
+    end
+
+    # AD Root settings
+    def root
+      @root ||= self.class.root
+    end
+
+    define_attribute_methods(
+      # User attributes
+      uid:              'uid',
+      email:            'mail',
+      first_name:       'givenName',
+      last_name:        'sn',
+      display_name:     'displayName'
+    )
+
+    def initialize_from(entry, options)
+      super
+      return if persisted?
+
+      @attributes['objectClass']          = %w( top person organizationalPerson user )
+      @attributes['userAccountControl'] ||= '544' # Normal user + No password required
+
+    end
+
+    def attributes
+      return super if persisted?
+
+      @cn = name
+
+      super.tap do |attrs|
+        attrs['displayName']       ||= name
+      end
+    end
+
+    def name
+      @attributes['name'] || @attributes.values_at('givenName', 'sn').join(' ').presence
+    end
+
+    def account_flags
+      self['userAccountControl'].to_i
+    end
+
+  end
+end

--- a/lib/ldap/model/railtie.rb
+++ b/lib/ldap/model/railtie.rb
@@ -22,31 +22,6 @@ module LDAP::Model
       end
     end
 
-    # We do not connect automatically on the test environment,
-    # to allow an application to mock everything out in tests.
-    #
-    initializer 'ldap_model.connect' do
-      conf = Pathname('config/ldap.yml')
-
-      begin
-        conf = YAML.load(conf.read).fetch(Rails.env)
-        LDAP::Model::Base.establish_connection(conf)
-      rescue => e
-        if Rails.env.test?
-          $stderr.puts "** LDAP: connection disabled (#{conf}: #{e.to_s})."
-          $stderr.puts "** To test LDAP integration, define a valid `test' environment."
-          LDAP::Model::ActiveRecord.disable!
-
-        elsif e.is_a?(Errno::ENOENT)
-          raise "LDAP configuration is missing, please create #{conf}"
-        elsif e.is_a?(KeyError)
-          raise "LDAP configuration for environment `#{Rails.env}' was not found in #{conf}"
-        else
-          raise
-        end
-      end
-    end
-
     config.after_initialize do
       if defined?(Hirb)
         require 'ldap/model/hirb'

--- a/lib/ldap/model/version.rb
+++ b/lib/ldap/model/version.rb
@@ -1,5 +1,5 @@
 module LDAP
   module Model
-    VERSION = "0.4.0"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/ldap/model/version.rb
+++ b/lib/ldap/model/version.rb
@@ -1,5 +1,5 @@
 module LDAP
   module Model
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
This PR adds the posibility to use ldap-model with multiple connections to different ldap servers, depending on the instance and not only on the class of the model.

It also removes establishing connections to ldap servers from the gem initializer and relies on the applications using the gem to setup the connections. 

This PR breaks backwards compatibility.


